### PR TITLE
Fix flow

### DIFF
--- a/app/src/main/java/com/google/firebase/firebaseuiauthmcve/MainActivity.java
+++ b/app/src/main/java/com/google/firebase/firebaseuiauthmcve/MainActivity.java
@@ -1,10 +1,12 @@
 package com.google.firebase.firebaseuiauthmcve;
 
+import android.content.Intent;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.firebase.ui.auth.AuthUI;
 import com.google.firebase.auth.FirebaseAuth;
@@ -33,7 +35,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                     String username = getString(R.string.signed_in_message, user.getDisplayName());
                     ((TextView) findViewById(R.id.signInTextView)).setText(username);
                 } else {
-                    // sign out
                     startActivityForResult(
                             AuthUI.getInstance()
                                     .createSignInIntentBuilder()
@@ -49,22 +50,40 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == RC_SIGN_IN) {
+            if (resultCode == RESULT_OK) {
+                // Sign-in succeeded, set up the UI
+                Toast.makeText(this, "Signed in!", Toast.LENGTH_SHORT).show();
+            } else if (resultCode == RESULT_CANCELED) {
+                // Sign in was canceled by the user, finish the activity
+                Toast.makeText(this, "Sign in canceled", Toast.LENGTH_SHORT).show();
+                finish();
+            }
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
         if (mAuthStateListener != null) {
             mFirebaseAuth.addAuthStateListener(mAuthStateListener);
         }
     }
 
     @Override
-    protected void onStop() {
-        super.onStop();
+    protected void onPause() {
+        super.onPause();
         mFirebaseAuth.removeAuthStateListener(mAuthStateListener);
     }
 
     @Override
     public void onClick(View view) {
-        AuthUI.getInstance()
-                .signOut(this);
+        switch (view.getId()) {
+            case R.id.signOutButton:
+                AuthUI.getInstance().signOut(this);
+                break;
+        }
     }
 }


### PR DESCRIPTION
Changes:
- Listen to `onActivityResult` to get the result of the sign-in flow
- Move to `onResume` / `onPause` so that the listener is detached when the sign-in flow is launched and re-attached **after** `onActivityResult` has been called.
